### PR TITLE
Port test-bank distractor refresh from source repo (Batch 3)

### DIFF
--- a/tools/ai-fluency-check.md
+++ b/tools/ai-fluency-check.md
@@ -641,7 +641,7 @@ const QUESTIONS_DATA = {
       "difficulty": "Core",
       "text": "Which best describes \"Narrow AI\"?",
       "options": [
-        "AI that operates only in restricted geographic regions.",
+        "AI that has been deployed in production for under one year.",
         "AI designed and trained for a specific task or domain.",
         "AI that runs on edge devices with constrained bandwidth.",
         "AI with fewer than one billion parameters."
@@ -706,7 +706,7 @@ const QUESTIONS_DATA = {
         "To reduce inference cost by caching responses.",
         "To let an LLM answer questions about information not in its training data, without retraining the model.",
         "To make the model run faster on smaller GPUs.",
-        "To eliminate hallucinations entirely (it doesn't)."
+        "To eliminate hallucinations entirely."
       ],
       "correct": 1
     },
@@ -737,7 +737,7 @@ const QUESTIONS_DATA = {
       "options": [
         "The model is larger.",
         "The system can plan, choose tools, take actions, and observe results in a loop.",
-        "It uses a vector database.",
+        "It always uses chain-of-thought prompting.",
         "It runs on dedicated hardware."
       ],
       "correct": 1
@@ -769,7 +769,7 @@ const QUESTIONS_DATA = {
       "options": [
         "An Anthropic-only experiment with limited adoption.",
         "An open standard governed by the Linux Foundation's Agentic AI Foundation, supported by Anthropic, OpenAI, and Google.",
-        "A deprecated protocol replaced by REST.",
+        "An OpenAPI-based spec maintained by IETF.",
         "A proprietary AWS-only specification."
       ],
       "correct": 1
@@ -800,7 +800,7 @@ const QUESTIONS_DATA = {
       "text": "Cursor, Claude Code, Cline, Aider, and Windsurf are best described as:",
       "options": [
         "IDEs and agentic CLIs that include LLM-powered code assistants tightly integrated with the editor or terminal.",
-        "Cloud-hosted CI runners.",
+        "Code formatters and linters that integrate with the editor.",
         "Static analysis tools.",
         "Vector database GUIs."
       ],
@@ -816,7 +816,7 @@ const QUESTIONS_DATA = {
       "text": "Devin and Replit Agent differ from Cursor and Cline in that:",
       "options": [
         "They use larger underlying models.",
-        "They run autonomously in cloud sandboxes; you assign a task and they plan, write, test, and submit a PR without you driving each step. Cursor and Cline are IDE-integrated assistants you drive interactively.",
+        "They run autonomously in cloud sandboxes; you assign a task and they plan, write, test, and submit a PR. Cursor and Cline are interactive IDE assistants you drive.",
         "They are open source while Cursor and Cline are proprietary.",
         "They only support JavaScript."
       ],
@@ -832,7 +832,7 @@ const QUESTIONS_DATA = {
       "text": "Which best describes the difference between 'JSON mode' and 'structured outputs' as offered by major LLM providers in 2026?",
       "options": [
         "JSON mode is for chat; structured outputs is for the chat completions API.",
-        "JSON mode guarantees valid JSON syntax. Structured outputs guarantees the response matches a provided JSON Schema (correct field names, correct types, all required fields) via constrained decoding.",
+        "JSON mode guarantees valid JSON syntax; structured outputs guarantees the response matches a provided JSON Schema via constrained decoding.",
         "They are different names for the same feature.",
         "JSON mode is open source; structured outputs is proprietary."
       ],
@@ -865,7 +865,7 @@ const QUESTIONS_DATA = {
       "options": [
         "Just request count.",
         "Request count, latency, token usage in/out, cost, and per-prompt success / quality signals.",
-        "Just GPU temperature.",
+        "Latency, cost, and request count, but not token usage, which is provider-internal.",
         "Just the system prompt content."
       ],
       "correct": 1
@@ -881,7 +881,7 @@ const QUESTIONS_DATA = {
       "scoring_rubric": "2 if the answer names a concrete technique (prompt or response caching, semantic caching, retrieval-result caching, smaller-model fallback for trivial queries, request batching, model quantisation/distillation, output token caps, system-prompt compression) AND offers a one-line 'why it works' rationale. 1 if it names a technique but the reasoning is hand-wavy. 0 otherwise.",
       "keyword_groups": [
         ["cach", "batch", "quanti", "distill", "fallback", "smaller model", "smaller-model", "compress", "summari", "max token", "output token", "token cap", "limit", "truncate", "prompt cache"],
-        ["because", "since", "reduce", "lower", "fewer", "less", "save", "cheaper", "faster", "avoid", "skip", "shorter", "smaller", "trivial", "common"]
+        ["reduce", "lower", "fewer", "less", "save", "cheaper", "faster", "avoid", "skip", "shorter", "smaller", "trivial", "common"]
       ]
     },
     {
@@ -894,7 +894,7 @@ const QUESTIONS_DATA = {
       "text": "Proxy-based observability (e.g. Helicone) and SDK-based observability (e.g. LangSmith, Langfuse) differ primarily in:",
       "options": [
         "Which programming languages they support.",
-        "Where the instrumentation lives. A proxy intercepts at the HTTP layer with zero code change but limited per-call detail. An SDK instruments inside your application with richer per-call detail at the cost of code changes.",
+        "Where the instrumentation lives: a proxy intercepts at the HTTP layer; an SDK instruments inside the application.",
         "Whether they cost money.",
         "Which LLM providers they support."
       ],
@@ -928,7 +928,7 @@ const QUESTIONS_DATA = {
         "The current chat context window.",
         "Persisted, retrievable state across sessions (e.g. a vector store of past interactions, key-value facts, summary memory).",
         "The model's training data.",
-        "GPU VRAM allocation."
+        "Few-shot examples in the system prompt."
       ],
       "correct": 1
     },
@@ -942,7 +942,7 @@ const QUESTIONS_DATA = {
       "text": "You're deploying a RAG service with bursty traffic and want to minimise idle cost. The most natural fit on AWS is:",
       "options": [
         "An always-on EC2 instance.",
-        "Lambda or Fargate (scale-to-zero) for the orchestration tier, with a managed retrieval/embedding backend (e.g. OpenSearch, Bedrock).",
+        "Lambda or Fargate for the orchestration tier (scale-to-zero), with a managed retrieval backend like OpenSearch or Bedrock.",
         "Bare metal in an on-prem rack.",
         "S3 only."
       ],
@@ -1022,7 +1022,7 @@ const QUESTIONS_DATA = {
         "GPU utilisation during inference.",
         "Answer faithfulness, context relevance/recall, and similar quality metrics for a RAG system.",
         "Network latency between regions.",
-        "Token compression ratios."
+        "Embedding-model perplexity."
       ],
       "correct": 1
     },
@@ -1035,7 +1035,7 @@ const QUESTIONS_DATA = {
       "difficulty": "Applied",
       "text": "You've made a 'small change' to your RAG pipeline (e.g. swapped the embedding model). The single most important thing to do before shipping:",
       "options": [
-        "Trust your gut and ship it.",
+        "Run the new pipeline against last week's user traffic and compare manually.",
         "Run your evaluation set against the new pipeline and compare quality regression vs the old one.",
         "Increase the temperature to compensate.",
         "Add more system-prompt instructions."
@@ -1051,7 +1051,7 @@ const QUESTIONS_DATA = {
       "difficulty": "Applied",
       "text": "You need to (i) measure your RAG system's answer faithfulness, (ii) write Pytest-style unit tests for prompts, and (iii) gate deploys in CI with prompt regression checks. The most natural 2026 toolchain:",
       "options": [
-        "Use one tool for everything; pick the most expensive.",
+        "DeepEval for (i), RAGAS for (ii), Inspect AI for (iii).",
         "RAGAS for (i), DeepEval for (ii), Promptfoo for (iii). They compose.",
         "Build all three from scratch.",
         "Skip evaluation; ship and watch errors."


### PR DESCRIPTION
## Summary

Mirrors [ImpactEng/ai-fluency-check@3036ab3](https://github.com/ImpactEng/ai-fluency-check/commit/3036ab3) into the inlined `QUESTIONS_DATA` literal on `tools/ai-fluency-check.md`. Source repo lands the change first; this PR is the marketing-side port.

13 questions touched, plus Q6.2 free-text keyword group 2 tightened.

### Distractor swaps (one weak option per question)

- Q1.1: "geographic regions" → "deployed in production for under one year"
- Q4.1: "uses a vector database" → "always uses chain-of-thought prompting"
- Q4.3: "deprecated, replaced by REST" → "OpenAPI-based spec maintained by IETF"
- Q5.2: "CI runners" → "Code formatters and linters that integrate with the editor"
- Q7.2: "GPU VRAM allocation" → "Few-shot examples in the system prompt"
- Q10.1: "Token compression ratios" → "Embedding-model perplexity"
- Q10.2: "Trust your gut and ship it" → "Run the new pipeline against last week's user traffic and compare manually"
- Q10.3: "Use one tool, pick the most expensive" → "DeepEval for (i), RAGAS for (ii), Inspect AI for (iii)"

### Distractor cleanup
- Q3.1 (d): drop the "(it doesn't)" giveaway parenthetical
- Q6.1 (c): silly singleton replaced with "Latency, cost, and request count, but not token usage, which is provider-internal"

### Correct-answer trims (length-asymmetry signal)
- Q5.3 (b), Q6.3 (b), Q8.1 (b), Q11.1 (b)

### Free-text Q6.2
- Drop "because" and "since" from keyword group 2

## Test plan

- [ ] CI / Jekyll build passes
- [ ] Quick run on `/tools/ai-fluency-check/` after merge: Q1.1, Q3.1 etc. show the new option text
- [ ] Deep run reaches Q5.2, Q5.3, Q6.x, Q7.2, Q8.x, Q10.x, Q11.1 and shows the new wording
- [ ] Q6.2 free-text: typing "I cache because it saves money" no longer scores 2 (must mention an actual cost-mechanism keyword to hit group 2)