### PR TITLE
Add F3 syllabus track (Prompt engineering and RAG basics)

### DIFF
--- a/tools/ai-fluency-check.md
+++ b/tools/ai-fluency-check.md
@@ -559,7 +559,36 @@ const QUESTIONS_DATA = {
     "F3": {
       "name": "Prompt engineering and RAG basics",
       "tier": "foundational",
-      "anchor": "You can choose between zero-shot, few-shot, and RAG for a problem, and you know when retrieval helps versus when it just adds latency."
+      "anchor": "You can choose between zero-shot, few-shot, and RAG for a problem, and you know when retrieval helps versus when it just adds latency.",
+      "syllabus": {
+        "read": {
+          "title": "Anthropic — Prompt engineering overview",
+          "url": "https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview",
+          "summary": "Current vendor-neutral techniques (be clear, use examples, give context, chain-of-thought) explained concretely with worked examples. 10 to 15 minutes. Focus on 'Be clear and direct', 'Use examples (multishot prompting)', and 'Let Claude think'. Skip the prompt-templates section; that is product-specific. Then read Pinecone's 'What is Retrieval Augmented Generation (RAG)?' (https://www.pinecone.io/learn/retrieval-augmented-generation/, 5 minutes, vendor-flavoured but accurate). The load-bearing idea: RAG lets the model answer questions about information it was not trained on, without retraining. Original source: Lewis et al. 2020 (https://arxiv.org/abs/2005.11401), intro and section 2 are the parts worth reading."
+        },
+        "try": {
+          "title": "Same question, three prompting strategies: build intuition for when retrieval pays off versus when a tight prompt is enough.",
+          "duration_minutes": 30,
+          "steps": [
+            "Pick a knowledge corpus you control: six markdown files from a project runbook, or your team's internal docs exported to plain text. Drop them in `~/scratch/rag-test/docs/`.",
+            "Write six questions: three where the answer is in the docs (the model would have to retrieve to know) and three where the answer is general knowledge (the model already knows).",
+            "Zero-shot: open Claude or ChatGPT in a fresh chat. Ask each of the six questions cold, no extra context. Record: correct, partially correct, or hallucinated.",
+            "Few-shot: prepend three Q-A examples (from the docs) to each prompt. Same six questions. Record again.",
+            "RAG: install the embeddings plugin (`pip install llm llm-sentence-transformers`). Index the docs: `llm embed-multi rag-test --files ~/scratch/rag-test/docs/ '*.md' --model sentence-transformers/all-MiniLM-L6-v2 --store`. For each question, retrieve top-3 chunks and pass them as context: `llm similar rag-test -c \"YOUR QUESTION\" -n 3 | llm \"Answer this question using the context above: YOUR QUESTION\"`.",
+            "Tabulate the three columns. Note where RAG wins (private-knowledge questions), where few-shot wins (format or style guidance), where zero-shot is fine (general knowledge), and the latency cost of the RAG path versus zero-shot."
+          ],
+          "outcome": "An intuitive map of when to reach for RAG. RAG earns its place for private or recent knowledge; for general questions it adds latency and a new failure mode (bad retrieval surfaces wrong chunks). For format and style consistency, few-shot beats both."
+        },
+        "tool": {
+          "title": "llm with embeddings (Simon Willison)",
+          "url": "https://llm.datasette.io/en/stable/embeddings/",
+          "summary": "Same `llm` you may have installed for F2; the `embed`, `embed-multi`, and `similar` subcommands are built in. Pure-Python, SQLite-backed, runs entirely locally. The `llm-sentence-transformers` plugin gives you free CPU-only embeddings; the OpenAI or Voyage plugins give you cloud embeddings if you want them. No vector database to run, no separate service.",
+          "power_user_followup": "Step up to Chroma (https://docs.trychroma.com/, `pip install chromadb`) once the basic embed flow feels normal. Adds persistent collections, metadata filtering, and is the most common entry-point vector DB in production RAG stacks. The same exercise on Chroma takes about 10 lines of Python and exposes you to the collection / metadata / where-filter shape you will see in Bedrock Knowledge Bases, Vertex AI Search, and Microsoft Foundry IQ."
+        },
+        "next_phase": {
+          "summary": "Adjacent topics worth pursuing once zero-shot vs few-shot vs RAG feels intuitive: advanced prompting techniques (chain-of-thought, self-consistency, prompt chaining) and production-grade RAG (chunking strategies, hybrid retrieval, reranking, query rewriting). External next reads if motivated: DAIR's Prompt Engineering Guide (https://www.promptingguide.ai/), still the most comprehensive open survey; pick the 'Techniques' section and skim. Anyscale, 'Building RAG-based LLM Applications for Production' (https://www.anyscale.com/blog/a-comprehensive-guide-for-building-rag-based-llm-applications-part-1), long; covers chunking, eval, deployment, and costs."
+        }
+      }
     },
     "F4": {
       "name": "Agentic AI and MCP",


### PR DESCRIPTION
## Summary

Ports the F3 syllabus track from [ImpactEng/ai-fluency-check@e8e5f84](https://github.com/ImpactEng/ai-fluency-check/commit/e8e5f84) into the inlined `QUESTIONS_DATA` literal on `tools/ai-fluency-check.md`.

After this lands, the third authored track (alongside F2 LLM mechanics and F4 Agentic AI and MCP) becomes available behind the "Show suggested next steps" toggle on the F3 (Prompt engineering and RAG basics) result card. F3 is the widest-reach foundational dimension; this closes one of the highest-value gaps in the syllabus library.

### Track shape

- **Read**: Anthropic prompt engineering overview + Pinecone RAG primer. ~15 minutes. Lewis et al. 2020 as optional original source.
- **Try**: "Same question, three prompting strategies." 6 questions (3 in-docs + 3 general) x zero-shot / few-shot / RAG, ~30 minutes. Builds intuition for when RAG pays off vs adds latency.
- **Tool**: `llm` with embeddings (Simon Willison) - reuses the F2 tool, exercising the `embed`/`embed-multi`/`similar` subcommands. Power-user follow-up: Chroma.
- **Next phase**: DAIR Prompt Engineering Guide + Anyscale production RAG guide.

### Diff shape

Targeted: only the F3 dimension's closing braces change. The marketing-side SEO additions (front matter `image:` line, trailing JSON-LD `SoftwareApplication` block) are preserved.

## Test plan

- [ ] CI / Jekyll build passes on this branch
- [ ] After merge: visit `/tools/ai-fluency-check/`, take a Quick run, hit results screen, expand "Show suggested next steps" on the F3 card
- [ ] Verify the F3 panel shows Read / Try / Tool / Next phase sections with clickable URLs and the `llm embed-multi` command rendered in `<code>` via the existing `formatRichText` helper
- [ ] Sitemap and SEO meta still intact (no regression from the targeted port)