### PR TITLE
Add A1 syllabus track (LLMOps)

### DIFF
--- a/tools/ai-fluency-check.md
+++ b/tools/ai-fluency-check.md
@@ -637,7 +637,36 @@ const QUESTIONS_DATA = {
     "A1": {
       "name": "LLMOps",
       "tier": "advanced",
-      "anchor": "You instrument LLM systems with cost, latency, token, and quality telemetry, and you reach for the right tool (proxy vs SDK, e.g. Helicone vs LangSmith vs Langfuse) for the situation."
+      "anchor": "You instrument LLM systems with cost, latency, token, and quality telemetry, and you reach for the right tool (proxy vs SDK, e.g. Helicone vs LangSmith vs Langfuse) for the situation.",
+      "syllabus": {
+        "read": {
+          "title": "Eugene Yan — Patterns for Building LLM-Based Systems & Products",
+          "url": "https://eugeneyan.com/writing/llm-patterns/",
+          "summary": "Vendor-neutral, comprehensive. ~15 minutes if focused. Skim the introduction; concentrate on the Eval, Caching, and Monitor sections, which carry the LLMOps shape. The cost, latency, and quality signals you instrument map directly onto what Eugene catalogues there. Then read Langfuse's 'What is LLM Observability?' (https://langfuse.com/docs, 5 minutes, vendor-flavoured but accurate). The dashboard screenshots show what the LLMOps baseline (cost per call, latency distribution, token in/out, trace tree, score breakdown) looks like in practice."
+        },
+        "try": {
+          "title": "Instrument 10 LLM calls and watch the cost, latency, and token breakdown materialise.",
+          "duration_minutes": 30,
+          "steps": [
+            "Spin up Langfuse locally with the published docker-compose recipe (https://langfuse.com/self-hosting/local). ~5 minutes. The web UI lands on http://localhost:3000 once the stack is healthy.",
+            "In a Python REPL or a 20-line script: install `langfuse openai` (or `anthropic`), set `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` from the local UI's project settings, and wrap your model client with the Langfuse `@observe` decorator.",
+            "Send 10 LLM calls with varied shapes: 5 short (~50 output tokens), 3 medium (~500 tokens), 2 long (~2000 tokens). Use prompts you genuinely care about (a runbook question, a code-review query, a summary, etc.).",
+            "Open the Langfuse UI. Click through the 10 traces.",
+            "Tabulate: median and p95 latency per category, total cost, tokens-in vs tokens-out ratio, the worst outlier (slowest, most expensive, longest), and which call category dominates the cost.",
+            "Add one deliberately bad prompt (ambiguous or ungrammatical) plus a quality score via `langfuse.score()`. Refresh the dashboard and notice how a score field changes which traces stand out."
+          ],
+          "outcome": "A concrete grasp of what observability gives you that print() does not. Per-call cost attribution catches expensive prompts you would not have flagged. The p95 latency view surfaces tail-latency outliers invisible in averages. Token in/out ratios change your prompt-budget intuition. Quality scores turn the dashboard from 'what happened' into 'what matters'."
+        },
+        "tool": {
+          "title": "Langfuse (self-hosted via docker-compose)",
+          "url": "https://langfuse.com/self-hosting/local",
+          "summary": "Open source, runs entirely local, no signup. The stack is Postgres plus ClickHouse plus a Next.js app and comes up in one `docker compose up`. SDK available for Python and JavaScript with decorator and context-manager flavours. The instrumentation shape (a span tree, scores, prompts, tags) maps onto the same shape Langfuse Cloud serves at production scale, so the local exercise carries forward.",
+          "power_user_followup": "Step up to Helicone (https://www.helicone.ai/) in proxy mode once the SDK pattern feels normal. A different instrumentation shape that intercepts at the HTTP layer instead of inside your code (change your OpenAI or Anthropic base URL, no SDK install). Run the same 10-call workload through Helicone and compare what each surface lets you see. That direct contrast is the proxy-versus-SDK trade-off from Q6.3 in muscle-memory form."
+        },
+        "next_phase": {
+          "summary": "Adjacent topics worth pursuing once LLM observability feels normal: LLM evaluation and quality (the natural progression to A5), production cost optimisation (semantic caching, smaller-model fallback for trivial queries, request batching, output token caps), and distributed tracing for LLM systems via OpenTelemetry plus OpenLLMetry. External next reads if motivated: Chip Huyen, 'Building LLM applications for production' (https://huyenchip.com/2023/04/11/llm-engineering.html) for the broader systems framing (long; ~40 minutes; pick the 'Operational considerations' sections). Langfuse blog (https://langfuse.com/blog) for the eval-stack story and recent production patterns."
+        }
+      }
     },
     "A2": {
       "name": "Agent design",


### PR DESCRIPTION
## Summary

Ports the A1 syllabus track from [ImpactEng/ai-fluency-check@80f02da](https://github.com/ImpactEng/ai-fluency-check/commit/80f02da) into the inlined `QUESTIONS_DATA` literal on `tools/ai-fluency-check.md`.

After this lands, the fourth authored track (alongside F2 LLM mechanics, F3 Prompt engineering and RAG basics, and F4 Agentic AI and MCP) becomes available behind the "Show suggested next steps" toggle on the A1 (LLMOps) result card. A1 is the highest-value advanced track for the DevOps/SRE/Cloud audience: their natural next layer once the foundational dimensions feel familiar.

### Track shape

- **Read**: Eugene Yan's *Patterns for Building LLM-Based Systems & Products* (vendor-neutral primary) + Langfuse docs intro (dashboard shape). ~20 minutes.
- **Try**: instrument 10 LLM calls via self-hosted Langfuse and watch the cost / latency / token breakdown materialise. ~30 minutes, 6 steps. Ends with a quality-score addition so the user feels how a score field changes the dashboard.
- **Tool**: Langfuse, self-hosted via docker-compose (open source, no signup, runs locally). Power-user follow-up: Helicone in proxy mode for the proxy-versus-SDK contrast from Q6.3.
- **Next phase**: A5 eval, production cost optimisation, OpenTelemetry plus OpenLLMetry. External reads: Chip Huyen LLM-engineering post + Langfuse blog.

### Diff shape

Targeted: only the A1 dimension's closing braces change. The marketing-side SEO additions (front matter `image:` line, trailing JSON-LD `SoftwareApplication` block) are preserved.

## Test plan

- [ ] CI / Jekyll build passes on this branch
- [ ] After merge: visit `/tools/ai-fluency-check/`, take a Deep run, reach the A1 result card, expand "Show suggested next steps"
- [ ] Verify the A1 panel renders Read / Try / Tool / Next phase sections with clickable URLs and the `docker compose up` and `langfuse.score()` snippets rendered in `<code>` via the existing `formatRichText` helper
- [ ] Sitemap and SEO meta still intact (no regression from the targeted port)