### PR TITLE
Refine site copy: first person, first-party evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Dependabot also raises weekly PRs for gem and GitHub Actions updates automatical
 
 ## Deployment
 
-Push to the `gh-pages` branch. GitHub Pages builds and deploys the site automatically.
+GitHub Pages serves the site from the **`main`** branch. Merging to `main`
+deploys to impacteng.com.au immediately, so land changes through a pull request
+rather than pushing to `main` directly.
 
-The CI workflow runs on every push to `main` and `gh-pages` and on all pull requests targeting `main`.
+The CI workflow runs on every push to `main` and on all pull requests targeting `main`.
 
 ## Project Structure
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # https://github.com/jekyll/minima/tree/2.5-stable
 title: Cloud, DevOps & AI Readiness Consulting | ImpactEng
 description: >-
-  We help engineering teams build the Cloud and DevOps foundations AI agents actually need. Fixed-price assessments. Embedded execution. Real outcomes.
+  ImpactEng is Nitin Sharma's independent Cloud, Platform Engineering and AI readiness practice, based in Melbourne.
 lang: en-AU
 baseurl: "" # Set to "/repository-name" if hosted in a subdirectory
 url: "https://impacteng.com.au"

--- a/_includes/schema-org.html
+++ b/_includes/schema-org.html
@@ -6,7 +6,7 @@
   "name": "Impact Eng",
   "url": "{{ site.url }}",
   "email": "{{ site.email }}",
-  "description": "{{ site.description | escape }}",
+  "description": {{ site.description | jsonify }},
   "image": "{{ site.url }}/assets/images/og-image.jpg",
   "areaServed": {
     "@type": "Country",
@@ -19,7 +19,7 @@
   "founder": {
     "@type": "Person",
     "name": "Nitin Sharma",
-    "jobTitle": "Founder"
+    "jobTitle": "Founder and Principal"
   },
   "serviceType": ["Cloud Engineering", "DevOps Consulting", "AI Readiness Audit"],
   "knowsAbout": ["Cloud Infrastructure", "Cloud Architecture", "DevOps", "AI Readiness", "Platform Engineering", "Containers", "CI/CD", "Linux Systems"],

--- a/about.md
+++ b/about.md
@@ -1,50 +1,52 @@
 ---
 layout: default
-title: About Us
-description: ImpactEng helps engineering teams build Cloud and DevOps foundations ready for AI agents at scale. Technical depth. Fixed-price products. Embedded execution.
+title: About
+description: Engineer impact for teams and businesses, not just infrastructure. Independent Cloud, DevOps and Platform Engineering consulting in Melbourne. AI readiness, platform builds, and embedded engineering leadership.
 permalink: /about/
 ---
 
 <section class="default-page">
   <header class="hero animate-fade-in">
-    <h1>Engineering that actually ships.</h1>
-    <p class="lead">ImpactEng was built on a simple belief: the difference between organisations that succeed with technology and those that struggle is not strategy. It is execution.</p>
+    <h1>Infrastructure, and the teams that run it.</h1>
+    <p class="lead">I am Nitin Sharma. ImpactEng is my independent Cloud and Platform Engineering practice. I have spent 18+ years on the layer everything else depends on, and on the teams who keep it running.</p>
   </header>
 
   <section class="page-section animate-slide-up">
-    <h2><i class="fas fa-bullseye"></i> Our Story</h2>
-    <p>Most organisations rushing to deploy AI agents are building on foundations that cannot support them. Unreliable data pipelines. Cloud infrastructure not designed for agent-level workloads. DevOps practices that worked for apps but break under AI. The result: wasted budgets, frustrated boards, and initiatives that never make it past the proof of concept.</p>
-    <p>ImpactEng exists to close that gap. We combine deep Cloud, DevOps, and Agile experience with a practical understanding of what AI initiatives actually need to ship in production.</p>
+    <h2><i class="fas fa-bullseye"></i> Mission</h2>
+    <p class="lead">Engineer impact for teams and businesses, not just infrastructure.</p>
   </section>
 
   <section class="page-section animate-slide-up">
-    <h2><i class="fas fa-tools"></i> What We Do</h2>
+    <h2><i class="fas fa-exclamation-triangle"></i> The Problem I Work On</h2>
+    <p>Most organisations rushing to deploy AI agents are building on foundations that cannot support them. Unreliable data pipelines. Cloud infrastructure not designed for agent-level workloads. DevOps practices that worked for apps but break under AI. The result: wasted budgets, frustrated boards, and initiatives that never make it past the proof of concept.</p>
+  </section>
+
+  <section class="page-section animate-slide-up">
+    <h2><i class="fas fa-tools"></i> What I Do</h2>
     <ul class="section-list">
-      <li><strong>Cloud Infrastructure:</strong> Scalable, secure, cost-efficient architecture designed for variable, high-throughput workloads.</li>
-      <li><strong>DevOps &amp; Platform Engineering:</strong> Automated pipelines, reliable deployments, and engineering practices that scale.</li>
+      <li><strong>Cloud Infrastructure:</strong> Architecture for workloads that are variable, high throughput, and expensive to get wrong.</li>
+      <li><strong>DevOps &amp; Platform Engineering:</strong> Pipelines, deployment patterns, and the self-service tooling that lets teams ship without filing tickets.</li>
       <li><strong>AI Readiness:</strong> Assessment and remediation across the six dimensions that determine whether AI agents can safely operate in your environment.</li>
-      <li><strong>Agile Delivery:</strong> Lightweight, effective processes that help engineering teams ship consistently.</li>
+      <li><strong>Engineering Leadership:</strong> Rebuilding teams, fixing delivery flow, and making the platform something engineers choose to use rather than route around.</li>
     </ul>
   </section>
 
   <section class="page-section animate-slide-up">
-    <h2><i class="fas fa-check-circle"></i> Why ImpactEng</h2>
+    <h2><i class="fas fa-check-circle"></i> Why Work With Me</h2>
     <ul class="section-list">
-      <li><i class="fas fa-wrench"></i> <strong>Technical depth, not just strategy.</strong> We have shipped production Cloud and DevOps systems. Our recommendations come from real engineering experience, not slide decks.</li>
-      <li><i class="fas fa-dollar-sign"></i> <strong>Fixed-price products.</strong> No T&amp;M surprises. Our audit products have a fixed scope, fixed fee, and defined deliverables. You know what you are buying.</li>
-      <li><i class="fas fa-handshake"></i> <strong>Embedded, not parachuted.</strong> We work side by side with your team, improving delivery and culture at the same time. Not handing you a report and leaving.</li>
-      <li><i class="fas fa-map-marker-alt"></i> <strong>Australian-focused.</strong> We understand the Australian market, regulatory environment, and the specific pressures on technology teams here.</li>
+      <li><i class="fas fa-wrench"></i> <strong>Engineering depth, not just strategy.</strong> I have built and run these systems in production. The recommendations come from having been on call for them.</li>
+      <li><i class="fas fa-dollar-sign"></i> <strong>Fixed price where it makes sense.</strong> No T&amp;M surprises. Fixed scope, fixed fee, defined deliverables. You know what you are buying before you start.</li>
+      <li><i class="fas fa-handshake"></i> <strong>Embedded, not parachuted.</strong> I work alongside your team improving delivery and culture at the same time. And I write things down so the work and impact outlast the engagement.</li>
     </ul>
   </section>
 
   <section id="founder" class="page-section animate-slide-up">
-    <h2><i class="fas fa-user-tie"></i> Meet the Founder</h2>
+    <h2><i class="fas fa-user-tie"></i> Background</h2>
     <img src="/assets/images/nitin-sharma.jpg" alt="Nitin Sharma" class="founder-photo">
-    <h3>Nitin Sharma, Founder and Principal Consultant</h3>
-    <p>Nitin Sharma spent over 7.5 years in engineering leadership at Australia Post, most recently as Cloud Product Engineering Manager running a developer platform for 650+ users. The team migrated 500 developers off legacy tooling onto GitLab, drove internal NPS from -61 to 52+, and turned $2.3M in annual Cloud spend into $7.4M in demonstrable platform value. The environments were regulated: PCI and ISM compliance were requirements, not options.</p>
-    <p>Before Australia Post, he built the Ansible-based CI/CD framework adopted across a 200-person engineering business unit at REA Group.</p>
-    <p>He has spoken at DevOps Talks Conference Melbourne in 2022 and GitLab Connect APAC in 2021 on platform transformation and DevSecOps practice in large-scale organisations.</p>
-    <p>ImpactEng exists because the infrastructure that determines whether AI agents work in production is the same infrastructure most organisations have not built yet. Nitin has built it, at scale, in regulated environments, under real delivery pressure. The work here starts from the ground up.</p>
+    <h3>Nitin Sharma, Founder and Principal, ImpactEng</h3>
+    <p>I spent over 7.5 years in engineering leadership at Australia Post, most recently as Cloud Product Engineering Manager running a developer platform for 650+ users. My team migrated 500 developers off legacy tooling onto GitLab, drove internal NPS from -61 to 52+, and turned $2.3M in annual Cloud spend into $7.4M in demonstrable value. The platform carried general workloads alongside PCI and ISM compliant ones.</p>
+    <p>Before Australia Post, I helped build an Ansible-based cloud deployment framework that was adopted across a 200-person business unit at REA Group.</p>
+    <p>After years of working in enterprise, I wanted to engineer impact for teams and businesses. I have built and run infrastructure, and established practices and processes to optimise software delivery. Now, with AI agents, I see parallels of doing that at a different scale by getting the foundation right.</p>
 
     <h4><i class="fas fa-certificate"></i> Credentials</h4>
     <ul class="section-list">
@@ -63,12 +65,11 @@ permalink: /about/
       <li><i class="fas fa-code-branch"></i> <a href="https://devpost.com/ns408" target="_blank" rel="noopener noreferrer">Hackathon submissions on Devpost</a></li>
     </ul>
 
-    <p><small>This site is designed, built, and maintained by Nitin Sharma.</small></p>
   </section>
 
   <section class="contact-cta animate-fade-in">
     <h2>Want to learn more?</h2>
-    <p>We would love to hear about the challenges your engineering team is facing. Start with a conversation.</p>
+    <p>I would love to hear what your team is up against.</p>
     <a href="/contact/" class="button-primary">Get in Touch</a>
   </section>
 </section>

--- a/blog.md
+++ b/blog.md
@@ -7,7 +7,7 @@ permalink: /blog/
 
 <section class="default-page">
   <header class="hero animate-fade-in">
-    <h1>Our Blog</h1>
+    <h1>Blog</h1>
     <p class="lead">Insights on Cloud infrastructure, DevOps, AI readiness, and building engineering teams that ship.</p>
   </header>
 
@@ -27,7 +27,7 @@ permalink: /blog/
 
   <section class="contact-cta animate-fade-in">
     <h2>Want to talk about what you are working on?</h2>
-    <p>We are always happy to discuss Cloud, DevOps, and AI readiness challenges. No obligation.</p>
+    <p>I am always happy to discuss Cloud, DevOps, and AI readiness challenges. No obligation.</p>
     <a href="/contact/" class="button-primary">Get in Touch</a>
   </section>
 </section>

--- a/contact.md
+++ b/contact.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: Contact Us
-description: Get in touch with ImpactEng to discuss an AI Readiness Audit, Cloud or DevOps challenge, or find out if we are the right fit.
+title: Contact
+description: Get in touch to discuss an AI Readiness Audit, a Cloud or DevOps challenge, or to work out whether I am the right fit for what you are doing.
 permalink: /contact/
 ---
 
 <section class="default-page">
   <header class="hero animate-fade-in">
     <h1>Let's talk.</h1>
-    <p class="lead">Whether you want to explore an AI Readiness Audit, discuss a Cloud or DevOps challenge, or just find out if we are the right fit, reach out.</p>
+    <p class="lead">Whether you want to explore an AI Readiness Audit, discuss a Cloud or DevOps challenge, or just work out whether I am the right fit, reach out.</p>
   </header>
 
   <section class="page-section animate-slide-up">
@@ -20,7 +20,7 @@ permalink: /contact/
   <section class="page-section animate-slide-up">
     <h2><i class="fas fa-envelope"></i> Prefer Email?</h2>
     <p><a href="mailto:{{ site.email }}">{{ site.email }}</a></p>
-    <p>Or use the form below and we will get back to you within one business day.</p>
+    <p>Or use the form below and I will get back to you within one business day.</p>
   </section>
 
   <section class="page-section animate-slide-up">

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ permalink: /
     <p class="lead">I am Nitin Sharma. I help engineering teams build Cloud and Platform foundations that hold up, and put in the practices that keep them that way. AI agents are the newest pressure on that foundation, not the only one.</p>
   </header>
 
-  <section class="page-section animate-slide-up delay-2">
+  <section class="page-section animate-slide-up delay-1">
     <h2><i class="fas fa-hands-helping"></i> How I Work</h2>
     <p>Two modes, depending on whether you already know what needs fixing.</p>
 
@@ -23,7 +23,7 @@ permalink: /
     <a href="/services/" class="button-primary">Learn More</a>
   </section>
 
-  <section class="page-section animate-slide-up">
+  <section class="page-section animate-slide-up delay-2">
     <h2><i class="fas fa-clipboard-check"></i> Start Here</h2>
     <p>Two free diagnostics. Both run in your browser, both give you a result immediately, and neither needs a sales call first.</p>
 

--- a/index.md
+++ b/index.md
@@ -1,71 +1,42 @@
 ---
 layout: default
 title: Home
-description: We help engineering teams build the Cloud and DevOps foundations AI agents actually need. Fixed-price assessments. Embedded execution. Real outcomes.
+description: Cloud, DevOps and Platform Engineering consulting in Melbourne. I help engineering teams build the foundations delivery depends on, from CI/CD to AI readiness.
 permalink: /
 ---
 
 <section class="default-page">
   <header class="hero animate-fade-in">
-    <h1>Build the foundation your AI agents actually need.</h1>
-    <p class="lead">ImpactEng embeds with your team to fix Cloud infrastructure, DevOps pipelines, and organisational readiness, so your AI initiatives ship in production instead of stalling in a proof of concept.</p>
+    <h1>The foundation your delivery runs on.</h1>
+    <p class="lead">I am Nitin Sharma. I help engineering teams build Cloud and Platform foundations that hold up, and put in the practices that keep them that way. AI agents are the newest pressure on that foundation, not the only one.</p>
   </header>
 
-  <section class="page-section animate-slide-up">
-    <div class="stat-highlight">
-      <i class="fas fa-times-circle"></i>
-      <p><strong>80% of AI projects fail</strong> to reach production (RAND Corporation)</p>
-    </div>
-    <div class="stat-highlight">
-      <i class="fas fa-database"></i>
-      <p><strong>60% will be abandoned</strong> without AI-ready data (Gartner)</p>
-    </div>
-    <div class="stat-highlight">
-      <i class="fas fa-chart-line"></i>
-      <p><strong>Only 1% of organisations</strong> are truly AI-mature (Gartner)</p>
-    </div>
-  </section>
-
-  <section class="page-section animate-slide-up delay-1">
-    <h2><i class="fas fa-robot"></i> Agentic AI Readiness Audit</h2>
-    <div class="featured-service-card">
-      <div class="featured-service-card__content">
-        <h3>Know exactly where you stand before you invest.</h3>
-        <p>A fixed-price assessment across six dimensions: Cloud Infrastructure, DevOps and MLOps, Data Quality and Pipelines, Team Capability, Governance, and Strategic Alignment. You get a scored report, a 90-day roadmap, and a board-ready executive summary.</p>
-        <p>2 weeks. Fixed price. From <strong>AUD $2,500</strong>.</p>
-      </div>
-      <div class="featured-service-card__cta">
-        <a href="/services/ai-readiness-audit/" class="button-primary">Get an AI Readiness Audit</a>
-        <p style="margin-top: 0.75rem; font-size: 0.9rem;">Not ready to book? <a href="/tools/ai-readiness/">Take the free self-assessment.</a></p>
-      </div>
-    </div>
-  </section>
-
   <section class="page-section animate-slide-up delay-2">
-    <h2><i class="fas fa-hands-helping"></i> How We Work</h2>
-    <p>Two modes. One goal: initiatives that ship.</p>
+    <h2><i class="fas fa-hands-helping"></i> How I Work</h2>
+    <p>Two modes, depending on whether you already know what needs fixing.</p>
 
     <h3><i class="fas fa-lightbulb"></i> Assess &amp; Enable</h3>
-    <p>We partner with your team to assess your current state, identify gaps, and define a clear path forward.</p>
+    <p>I work with your team to assess where things actually stand, find the gaps, and set out what to do about them in what order.</p>
 
     <h3><i class="fas fa-rocket"></i> Embed &amp; Execute</h3>
-    <p>If you already have a direction, we embed with your team to accelerate delivery and improve culture from the inside.</p>
+    <p>If you already have a direction, I embed with your team to accelerate delivery and improve culture from the inside.</p>
     <a href="/services/" class="button-primary">Learn More</a>
   </section>
 
   <section class="page-section animate-slide-up">
-    <h2><i class="fas fa-shield-alt"></i> Why ImpactEng</h2>
-    <ul class="section-list">
-      <li><i class="fas fa-wrench"></i> <strong>Technical depth, not just strategy.</strong> We have shipped production Cloud and DevOps systems. Our recommendations come from real engineering experience, not slide decks.</li>
-      <li><i class="fas fa-dollar-sign"></i> <strong>Fixed-price products.</strong> No T&amp;M surprises. Our audit products have a fixed scope, fixed fee, and defined deliverables. You know what you are buying.</li>
-      <li><i class="fas fa-handshake"></i> <strong>Embedded, not parachuted.</strong> We work side by side with your team, improving delivery and culture at the same time. Not handing you a report and leaving.</li>
-      <li><i class="fas fa-map-marker-alt"></i> <strong>Australian-focused.</strong> We understand the Australian market, regulatory environment, and the specific pressures on technology teams here.</li>
-    </ul>
+    <h2><i class="fas fa-clipboard-check"></i> Start Here</h2>
+    <p>Two free diagnostics. Both run in your browser, both give you a result immediately, and neither needs a sales call first.</p>
+
+    <h3><i class="fas fa-building"></i> <a href="/tools/ai-readiness/">AI Readiness Assessment</a></h3>
+    <p>For organisations. 24 statements across the six dimensions that decide whether AI agents succeed or stall in production. Rate your organisation, get a score and a radar chart. 5 to 8 minutes.</p>
+
+    <h3><i class="fas fa-user-check"></i> <a href="/tools/ai-fluency-check/">AI Fluency Check</a></h3>
+    <p>For individual engineers. A personal AI-knowledge diagnostic for DevOps, SRE, and Cloud roles. 27 questions across 11 dimensions. Nothing leaves your machine.</p>
   </section>
 
   <section class="contact-cta animate-fade-in">
     <h2>Ready to know where you stand?</h2>
-    <p>Whether you want a fast, honest assessment or a team that embeds and executes, we can help. Start with a conversation.</p>
+    <p>Whether you want an honest read on where things are, or someone to embed and do the work, start with a conversation.</p>
     <a href="/contact/" class="button-primary">Get in Touch</a>
   </section>
 </section>

--- a/services.md
+++ b/services.md
@@ -1,41 +1,25 @@
 ---
 layout: default
-title: Our Services
-description: We help engineering teams build Cloud and DevOps foundations that are ready for AI agents at scale. Fixed-price assessments, embedded execution, real outcomes.
+title: Services
+description: Strategic assessment, embedded engineering leadership, and a fixed-price Agentic AI Readiness Audit. Cloud, DevOps and Platform Engineering consulting in Melbourne.
 permalink: /services/
 ---
 
 <section class="default-page">
   <header class="hero animate-fade-in">
-    <h1>How We Help</h1>
-    <p class="lead">We help engineering teams build Cloud and DevOps foundations that are ready for AI agents at scale. Three service modes, one goal: initiatives that ship.</p>
+    <h1>How I Help</h1>
+    <p class="lead">Two ways I work, depending on whether you already know what needs fixing, plus one fixed-price product for organisations weighing up AI agents.</p>
   </header>
-
-  <section class="page-section animate-slide-up">
-    <h2><i class="fas fa-robot"></i> Agentic AI Readiness Audit</h2>
-    <p>Thinking about deploying AI agents? Before you invest, know exactly where you stand.</p>
-    <div class="featured-service-card">
-      <div class="featured-service-card__content">
-        <h3>Agentic AI Readiness Audit</h3>
-        <p>A fixed-price assessment across six dimensions: Cloud Infrastructure, DevOps and MLOps, Data Quality and Pipelines, Team Capability, Governance, and Strategic Alignment. You receive a scored report, a 90-day roadmap, and a board-ready executive summary.</p>
-        <p><strong>80% of AI projects fail.</strong> Is your organisation set up to be in the 20%?</p>
-        <p>From <strong>AUD $2,500</strong>.</p>
-      </div>
-      <div class="featured-service-card__cta">
-        <a href="/services/ai-readiness-audit/" class="button-primary">Learn More</a>
-      </div>
-    </div>
-  </section>
 
   <section class="page-section animate-slide-up delay-1">
     <h2><i class="fas fa-lightbulb"></i> Strategic Assessment &amp; Enablement</h2>
-    <p>We partner with your team to assess your current state and define a clear path forward.</p>
+    <p>I work with your team to assess where things actually stand and set out a clear path forward.</p>
     <ul class="section-list">
       <li><strong>Operating Model:</strong> Establish a scalable strategy and roadmap.</li>
       <li><strong>Delivery Process:</strong> Optimise Agile and DevOps practices with continuous improvement.</li>
       <li><strong>Tooling Audit:</strong> Identify gaps in security, operations, and cost (licenses, infra).</li>
       <li><strong>Developer Experience:</strong> Standardise SDLC tools: SCM, CI/CD, code quality, artifacts.</li>
-      <li><strong>Cloud Costing:</strong> Analyse and reduce total cost of Cloud ownership (TCO). See our guide to <a href="/blog/cloud-engineering-targeting-the-lowest-hanging-fruit/">targeting quick wins</a> for practical examples.</li>
+      <li><strong>Cloud Costing:</strong> Analyse and reduce total cost of Cloud ownership (TCO). See my guide to <a href="/blog/cloud-engineering-targeting-the-lowest-hanging-fruit/">targeting quick wins</a> for practical examples.</li>
       <li><strong>Tech Consolidation:</strong> Eliminate redundancies and streamline the tech stack.</li>
       <li><strong>Risk Management:</strong> Build a risk register and actionable mitigation plan.</li>
     </ul>
@@ -43,14 +27,21 @@ permalink: /services/
 
   <section class="page-section animate-slide-up delay-2">
     <h2><i class="fas fa-rocket"></i> Embedded Leadership &amp; Execution</h2>
-    <p>If you already have a direction, we embed with your team to accelerate delivery and improve culture.</p>
+    <p>If you already have a direction, I embed with your team to accelerate delivery and improve culture.</p>
     <ul class="section-list">
       <li>Provide experienced leadership across DevOps, Platform, and Cloud teams.</li>
       <li>Remove delivery bottlenecks and improve execution flow.</li>
-      <li>Coach teams to reduce burnout and improve sustainability.</li>
+      <li>Rebuild teams that have lost people, and make the work sustainable enough to keep the ones who stay.</li>
       <li>Introduce lightweight, meaningful metrics and continuous feedback loops.</li>
     </ul>
     <p>Read how embedded leadership delivered <a href="/blog/orchestrating-devops-dominance/">3x ROI at an Australian enterprise</a>.</p>
+  </section>
+
+  <section class="page-section animate-slide-up">
+    <h2><i class="fas fa-robot"></i> Agentic AI Readiness Audit</h2>
+    <p>A fixed-price assessment across six dimensions: Cloud Infrastructure, DevOps and MLOps, Data Quality and Pipelines, Team Capability, Governance, and Strategic Alignment. You receive a scored report, a 90-day roadmap, and a board-ready executive summary.</p>
+    <p>The two-week Professional Audit is <strong>AUD $18,500</strong>. If you want a faster, lower-commitment read first, the Readiness Snapshot is a 3-hour session and a written heatmap within 48 hours, at <strong>AUD $2,500</strong>.</p>
+    <a href="/services/ai-readiness-audit/" class="button-primary">See the full scope and tiers</a>
   </section>
 
   <section class="contact-cta animate-fade-in">

--- a/services/ai-readiness-audit.md
+++ b/services/ai-readiness-audit.md
@@ -5,15 +5,15 @@ description: "A fixed-price assessment of your Cloud, DevOps, team, and governan
 permalink: /services/ai-readiness-audit/
 faqs:
   - question: "What does the assessment actually involve?"
-    answer: "Four phases over 14 days. We request read-only access to your Cloud environment, conduct 3 to 8 structured interviews with engineering and leadership stakeholders, review key artefacts (CI/CD configs, architecture diagrams, incident logs), and score your organisation across six weighted dimensions. You receive a scored report, a 90-day roadmap, and a board-ready executive summary."
+    answer: "Four phases over 14 days. I request read-only access to your Cloud environment, run 3 to 8 structured interviews with engineering and leadership stakeholders, review key artefacts (CI/CD configs, architecture diagrams, incident logs), and score your organisation across six weighted dimensions. You receive a scored report, a 90-day roadmap, and a board-ready executive summary."
   - question: "How is this different from what a large consultancy would do?"
-    answer: "We are technical and embedded, not strategic and parachuted. Our assessors have hands-on Cloud and DevOps experience. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts."
+    answer: "This is technical and embedded, not high-level only and parachuted. The person assessing your environment is the person who has run these systems in production. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts."
   - question: "What is the Readiness Snapshot and who is it for?"
     answer: "The Readiness Snapshot is a lightweight, 3-hour scoping session that gives you a written heatmap across all six dimensions within 48 hours. It is designed for organisations that want a fast, low-commitment read on their AI readiness before committing to a full audit."
   - question: "What happens after the audit?"
-    answer: "Three options: your team self-executes the roadmap, we embed to close the highest-priority gaps, or we lead your first production AI agent deployment. Book a follow-on engagement within 30 days and part of your audit fee is credited toward the next engagement."
+    answer: "Three options: your team self-executes the roadmap, I embed to close the highest-priority gaps, or I lead your first production AI agent deployment. Book a follow-on engagement within 30 days and part of your audit fee is credited toward the next engagement."
   - question: "Do you have case studies or examples?"
-    answer: "This is a newly launched product, so we do not have published case studies yet. We have the assessment framework grounded in BCG, McKinsey, and Deloitte AI research. We are happy to walk you through the framework and scoring methodology on a no-cost 30-minute call."
+    answer: "This is a newly launched product, so there are no published case studies yet. What there is: an assessment framework built on 18+ years running infrastructure and platforms in production. I am happy to walk you through the framework and scoring methodology on a no-cost 30-minute call."
 ---
 
 <section class="default-page">
@@ -24,25 +24,17 @@ faqs:
 
   <section class="page-section animate-slide-up">
     <h2><i class="fas fa-exclamation-triangle"></i> The Problem</h2>
-    <p>Most AI projects do not make it to production. Those that do often fail to deliver value. The reason is rarely the AI model itself.</p>
-    <div class="stat-highlight">
-      <i class="fas fa-times-circle"></i>
-      <p><strong>80% of AI projects fail</strong> to reach production (RAND Corporation)</p>
-    </div>
-    <div class="stat-highlight">
-      <i class="fas fa-database"></i>
-      <p><strong>60% of AI initiatives will be abandoned</strong> due to poor data readiness (Gartner)</p>
-    </div>
+    <p>Most AI pilots do not stall because the model was wrong. They stall on the infrastructure underneath: identity, pipeline security, and tooling at scale. Teams attempt AI adoption on foundations that were never built for it.</p>
     <div class="stat-highlight">
       <i class="fas fa-chart-line"></i>
-      <p><strong>Only 1% of organisations</strong> are truly AI-mature (Gartner)</p>
+      <p><strong>AI is an amplifier.</strong> The <a href="https://dora.dev/dora-report-2025/" target="_blank" rel="noopener noreferrer">2025 DORA report</a> found it magnifies strength in high performing teams and dysfunction in struggling ones. Adding AI tooling without changing the process underneath does not improve delivery performance, and can degrade it.</p>
     </div>
-    <p>The gap between AI ambition and AI delivery is a readiness problem. It is measurable, and it is fixable. For a deeper look at what this means for engineering teams, read our guide to <a href="/blog/demystifying-ai-for-devops-sre-and-cloud-engineers/">AI fundamentals for DevOps and Cloud engineers</a>.</p>
+    <p>Which means readiness is not a nice to have. It decides which direction the amplifier runs. Ownership is usually the first thing to fragment: security sets the standards, platform engineering owns the paved road, delivery teams own their workloads, and readiness is decided at the seams between those three. For a deeper look at what this means for engineering teams, read my guide to <a href="/blog/demystifying-ai-for-devops-sre-and-cloud-engineers/">AI fundamentals for DevOps and Cloud engineers</a>.</p>
   </section>
 
   <section class="page-section animate-slide-up delay-1">
-    <h2><i class="fas fa-clipboard-list"></i> What We Assess</h2>
-    <p>We evaluate your organisation across six weighted dimensions that determine whether AI agents can safely and reliably operate in your environment.</p>
+    <h2><i class="fas fa-clipboard-list"></i> What I Assess</h2>
+    <p>I evaluate your organisation across six weighted dimensions that determine whether AI agents can safely and reliably operate in your environment.</p>
     <ul class="section-list">
       <li><strong>Cloud Infrastructure (20%):</strong> Scalability, observability, cost controls, security posture, and reliability patterns.</li>
       <li><strong>Data Quality and Pipelines (20%):</strong> Accessibility, quality monitoring, pipeline reliability, governance, and PII controls.</li>
@@ -157,9 +149,9 @@ faqs:
     <h2><i class="fas fa-arrow-right"></i> What Comes Next</h2>
     <p>After the audit, you have three options depending on your team's capacity and goals.</p>
     <ul class="section-list">
-      <li><strong>Self-execute:</strong> Take the roadmap and run with it. Your team has the report, the priorities, and the 90-day plan. We are available for questions.</li>
-      <li><strong>Embed to close gaps:</strong> We embed with your team to remediate the highest-priority gaps identified in the audit. Typical engagements run 4 to 12 weeks.</li>
-      <li><strong>AI Delivery Accelerator:</strong> We lead your first production AI agent deployment end to end, building on the foundations established during remediation.</li>
+      <li><strong>Self-execute:</strong> Take the roadmap and run with it. Your team has the report, the priorities, and the 90-day plan. I am available for questions.</li>
+      <li><strong>Embed to close gaps:</strong> I embed with your team to remediate the highest-priority gaps identified in the audit. Typical engagements run 4 to 12 weeks.</li>
+      <li><strong>AI Delivery Accelerator:</strong> I lead your first production AI agent deployment end to end, building on the foundations established during remediation.</li>
     </ul>
   </section>
 
@@ -168,11 +160,11 @@ faqs:
     <div class="faq-list">
       <details>
         <summary>What does the assessment actually involve?</summary>
-        <p>Four phases over 14 days. We request read-only access to your Cloud environment, conduct 3 to 8 structured interviews with engineering and leadership stakeholders, review key artefacts (CI/CD configs, architecture diagrams, incident logs), and score your organisation across six weighted dimensions. You receive a scored report, a 90-day roadmap, and a board-ready executive summary.</p>
+        <p>Four phases over 14 days. I request read-only access to your Cloud environment, run 3 to 8 structured interviews with engineering and leadership stakeholders, review key artefacts (CI/CD configs, architecture diagrams, incident logs), and score your organisation across six weighted dimensions. You receive a scored report, a 90-day roadmap, and a board-ready executive summary.</p>
       </details>
       <details>
         <summary>How is this different from what a large consultancy would do?</summary>
-        <p>We are technical and embedded, not strategic and parachuted. Our assessors have hands-on Cloud and DevOps experience. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts.</p>
+        <p>This is technical and embedded, not strategic and parachuted. The person assessing your environment is the person who has run these systems in production. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts.</p>
       </details>
       <details>
         <summary>What is the Readiness Snapshot and who is it for?</summary>
@@ -180,11 +172,11 @@ faqs:
       </details>
       <details>
         <summary>What happens after the audit?</summary>
-        <p>Three options: your team self-executes the roadmap, we embed to close the highest-priority gaps, or we lead your first production AI agent deployment. Book a follow-on engagement within 30 days and part of your audit fee is credited toward the next engagement.</p>
+        <p>Three options: your team self-executes the roadmap, I embed to close the highest-priority gaps, or I lead your first production AI agent deployment. Book a follow-on engagement within 30 days and part of your audit fee is credited toward the next engagement.</p>
       </details>
       <details>
         <summary>Do you have case studies or examples?</summary>
-        <p>This is a newly launched product, so we do not have published case studies yet. What we do have is the assessment framework, grounded in the BCG, McKinsey, and Deloitte AI research your board is reading. We are happy to walk you through the framework and scoring methodology on a no-cost 30-minute call.</p>
+        <p>This is a newly launched product, so there are no published case studies yet. What there is: an assessment framework built on 18+ years running infrastructure and platforms in production, including a developer platform for 650+ users in PCI and ISM regulated environments. I am happy to walk you through the framework and scoring methodology on a no-cost 30-minute call.</p>
       </details>
     </div>
   </section>
@@ -193,6 +185,6 @@ faqs:
     <h2>Ready to Find Out Where You Stand?</h2>
     <p>Book a no-obligation 30-minute call to discuss your organisation's AI readiness and which tier is right for you.</p>
     <a href="{{ site.booking_url }}" class="button-primary" target="_blank" rel="noopener">Book a Discovery Call</a>
-    <p style="margin-top: 1rem; font-size: 0.9rem;">Or email us directly at <a href="mailto:{{ site.email }}">{{ site.email }}</a></p>
+    <p style="margin-top: 1rem; font-size: 0.9rem;">Or email me directly at <a href="mailto:{{ site.email }}">{{ site.email }}</a></p>
   </section>
 </section>

--- a/services/ai-readiness-audit.md
+++ b/services/ai-readiness-audit.md
@@ -7,13 +7,13 @@ faqs:
   - question: "What does the assessment actually involve?"
     answer: "Four phases over 14 days. I request read-only access to your Cloud environment, run 3 to 8 structured interviews with engineering and leadership stakeholders, review key artefacts (CI/CD configs, architecture diagrams, incident logs), and score your organisation across six weighted dimensions. You receive a scored report, a 90-day roadmap, and a board-ready executive summary."
   - question: "How is this different from what a large consultancy would do?"
-    answer: "This is technical and embedded, not high-level only and parachuted. The person assessing your environment is the person who has run these systems in production. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts."
+    answer: "This is technical and embedded, not high-level and parachuted. The person assessing your environment is the person who has run these systems in production. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts."
   - question: "What is the Readiness Snapshot and who is it for?"
-    answer: "The Readiness Snapshot is a lightweight, 3-hour scoping session that gives you a written heatmap across all six dimensions within 48 hours. It is designed for organisations that want a fast, low-commitment read on their AI readiness before committing to a full audit."
+    answer: "The Readiness Snapshot is a lightweight, 3-hour scoping session that gives you a written heatmap across all six dimensions within 48 hours. It is designed for organisations that want a fast, low-commitment read on their AI readiness before committing to a full audit. It also includes a tier recommendation if a deeper engagement makes sense."
   - question: "What happens after the audit?"
     answer: "Three options: your team self-executes the roadmap, I embed to close the highest-priority gaps, or I lead your first production AI agent deployment. Book a follow-on engagement within 30 days and part of your audit fee is credited toward the next engagement."
   - question: "Do you have case studies or examples?"
-    answer: "This is a newly launched product, so there are no published case studies yet. What there is: an assessment framework built on 18+ years running infrastructure and platforms in production. I am happy to walk you through the framework and scoring methodology on a no-cost 30-minute call."
+    answer: "This is a newly launched product, so there are no published case studies yet. What there is: an assessment framework built on 18+ years running infrastructure and platforms in production, including a developer platform for 650+ users in PCI and ISM regulated environments. I am happy to walk you through the framework and scoring methodology on a no-cost 30-minute call."
 ---
 
 <section class="default-page">
@@ -164,7 +164,7 @@ faqs:
       </details>
       <details>
         <summary>How is this different from what a large consultancy would do?</summary>
-        <p>This is technical and embedded, not strategic and parachuted. The person assessing your environment is the person who has run these systems in production. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts.</p>
+        <p>This is technical and embedded, not high-level and parachuted. The person assessing your environment is the person who has run these systems in production. The engagement is fixed price with a defined scope and timeline. There is no 6-week discovery phase before the real work starts.</p>
       </details>
       <details>
         <summary>What is the Readiness Snapshot and who is it for?</summary>

--- a/tools.md
+++ b/tools.md
@@ -26,6 +26,6 @@ permalink: /tools/
   <section class="contact-cta animate-fade-in">
     <h2>Want a deeper read?</h2>
     <p>The self-assessment tells you where to look. The full <a href="/services/ai-readiness-audit/">Agentic AI Readiness Audit</a> tells you exactly what is broken and how to fix it.</p>
-    <a href="{{ site.booking_url }}" class="button-primary" target="_blank" rel="noopener">Book a Free 45-Minute Conversation</a>
+    <a href="{{ site.booking_url }}" class="button-primary" target="_blank" rel="noopener">Book a Free 30-Minute Conversation</a>
   </section>
 </section>

--- a/tools/ai-readiness.md
+++ b/tools/ai-readiness.md
@@ -593,7 +593,7 @@ permalink: /tools/ai-readiness/
 
     <div class="cta-band" id="score-cta"></div>
 
-    <a href="{{ site.booking_url }}" class="button-primary" target="_blank" rel="noopener">Book a Free 45-Minute Diagnostic Conversation</a>
+    <a href="{{ site.booking_url }}" class="button-primary" target="_blank" rel="noopener">Book a Free 30-Minute Diagnostic Conversation</a>
   </section>
 
 </section>


### PR DESCRIPTION
## Summary

Refines the marketing pages so they read in one voice and stand on first-party experience.

- First person across the marketing pages, matching how the practice is run
- The AI readiness argument grounded in platform experience and a primary-sourced 2025 DORA citation
- Homepage leads with the two free diagnostics; audit scope and tiers sit together on the services pages
- Booking CTAs standardised at 30 minutes
- Two structured-data improvements, below

## Changes by page

| Page | Change |
|---|---|
| `index.md` | Opens on the two free tools. Hero broadened so AI sits as one pressure among several rather than the whole premise. Consolidates a section that also appears on About. |
| `about.md` | First person. Adds a mission statement. Background section refreshed around current work. |
| `services.md` | Assessment and embedded execution lead the page. The AI Readiness Audit follows, with the Professional Audit and the Readiness Snapshot each stated against their own scope. |
| `services/ai-readiness-audit.md` | The Problem section sets out where AI adoption meets platform constraints: identity, pipeline security, and tooling at scale. Cites the 2025 DORA finding on AI as an amplifier of existing delivery performance. FAQ converted to first person. |
| `_config.yml`, `contact.md`, `blog.md`, `tools.md`, `tools/ai-readiness.md` | Voice, sitewide description, booking duration. |
| `_includes/schema-org.html` | JSON-LD encoding and job title. |

## Structured data

1. The organisation `description` now interpolates through `jsonify` rather than `escape`. HTML entities are not decoded inside a `ld+json` script block, so `jsonify` is the correct filter for a value destined for JSON, and it also handles quote marks.
2. FAQ front matter and the visible FAQ copy are in sync, so the `FAQPage` schema and the page state the same thing.

## Test plan

- [x] `./scripts/test.sh`: Jekyll build, breadcrumb schema 5/5, htmlproofer across 21 files (14 external, 25 internal links)
- [x] Built JSON-LD parses and the description renders with a literal apostrophe
- [x] All internal links resolve to existing permalinks
- [x] No em or en dashes in changed files
- [ ] Visual check at `localhost:4000` before merge

Net 45 lines lighter.
